### PR TITLE
Improve deployment reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Environment variables
+.env
+
+# Logs
+journal.json

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ OPENAI_API_KEY=your-api-key-here
 streamlit run app.py
 ```
 
+The app stores chat history in `journal.json`. When deploying, make sure the
+`OPENAI_API_KEY` environment variable is defined and that the process has write
+access to this file.
+
 ## Features
 
 - **Streamlit Chat UI** – chat with GPT‑4 in your browser.

--- a/app.py
+++ b/app.py
@@ -42,6 +42,9 @@ def append_log(user_msg, assistant_msg, rating=None):
 
 
 def get_response(prompt: str) -> str:
+    if not OPENAI_API_KEY:
+        return "OpenAI API key is missing."
+
     history = load_history()
     messages = [
         {"role": "system", "content": "You are a helpful personal assistant."},
@@ -57,7 +60,7 @@ def get_response(prompt: str) -> str:
 
 
 st.title("Personal AI Assistant")
-user_input = st.text_input("You:")
+user_input = st.text_input("You:", key="user_input")
 
 if st.button("Send"):
     if user_input:
@@ -65,7 +68,11 @@ if st.button("Send"):
             reply = get_response(user_input)
         st.markdown(f"**Assistant:** {reply}")
         rating = st.slider(
-            "Rate the response:", 1, 5, 3, key=f"rating_{len(st.session_state.history)}"
+            "Rate the response:",
+            1,
+            5,
+            3,
+            key=f"rating_{len(st.session_state.history)}",
         )
         append_log(user_input, reply, rating)
         st.session_state.user_input = ""


### PR DESCRIPTION
## Summary
- cleanup: ignore `__pycache__`, `.env`, and log file
- improve README with deployment note
- update `app.py` to use keyed text input and check for missing API key

## Testing
- `python -m py_compile app.py`
- `pyflakes app.py`
- `black --check app.py`
- `OPENAI_API_KEY="sk-test" streamlit run app.py --server.headless true`

------
https://chatgpt.com/codex/tasks/task_e_6849d1bc49f48323a38a77c5f7e7dd31